### PR TITLE
Feat/ajust pontuacao scrum

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -94,14 +94,14 @@ function calculateOverload() {
             }
         });
 
-        // Soma para o Scrum Master
-        // Nota: Geralmente SM ganha +2 fixo, mas mantive sua lógica de somar os pontos do projeto
-        // Se quiser fixo, troque 'points' por 2 na linha abaixo.
-        const smId = proj.scrum_master_id || proj.scrum_master; // Aceita os dois formatos
+        // Soma para o Scrum Master — peso proporcional à complexidade do projeto
+        // Fórmula: max(1, round(points * 0.4)) → 1 pt p/ baixa, 2 p/ média, 3-4 p/ alta complexidade
+        const smId = proj.scrum_master_id || proj.scrum_master;
         if (smId) {
             const sm = members.find(m => m.id === smId);
             if (sm) {
-                sm.overload += 2; // (Recomendado: SM ganha +2 fixo. Se quiser o valor do projeto, use 'points')
+                const smPoints = Math.max(1, Math.round(points * 0.4));
+                sm.overload += smPoints;
             }
         }
     });

--- a/js/scrum.js
+++ b/js/scrum.js
@@ -81,14 +81,6 @@ if (scrumForm) {
             return;
         }
 
-        // Verifica se o membro está alocado no projeto (Regra de Negócio)
-        // Nota: O campo no banco é allocated_members (snake_case)
-        const allocated = project.allocated_members || [];
-        if (!allocated.includes(scrumMasterId)) {
-            showFloatingAlert('Este membro não está alocado no projeto. Aloque-o antes de torná-lo Scrum Master.', 'warning');
-            return;
-        }
-
         // 3. Feedback Visual
         const submitBtn = this.querySelector('button[type="submit"]');
         const originalText = submitBtn.innerHTML;

--- a/js/supabase.js
+++ b/js/supabase.js
@@ -146,9 +146,27 @@ const ProjectService = {
 
     // Função específica rápida apenas para trocar o SM (opcional, mas útil)
     async definirScrumMaster(projectId, scrumMasterId) {
+        const updatePayload = { scrum_master: scrumMasterId || null };
+
+        // Se está atribuindo um SM, garante que ele está no allocated_members
+        if (scrumMasterId) {
+            const { data: current, error: fetchError } = await _supabase
+                .from('projects')
+                .select('allocated_members')
+                .eq('id', projectId)
+                .single();
+
+            if (fetchError) return { success: false, error: fetchError.message };
+
+            const allocated = current.allocated_members || [];
+            if (!allocated.includes(scrumMasterId)) {
+                updatePayload.allocated_members = [...allocated, scrumMasterId];
+            }
+        }
+
         const { data, error } = await _supabase
             .from('projects')
-            .update({ scrum_master: scrumMasterId || null })
+            .update(updatePayload)
             .eq('id', projectId)
             .select();
 


### PR DESCRIPTION
## Ajuste de atribuição e pontuação do Scrum Master

### O que mudou

**Alocação automática ao definir Scrum Master**

Antes era obrigatório alocar o membro no projeto antes de torná-lo Scrum Master. Agora essa restrição foi removida — ao selecionar um SM, o sistema verifica se ele já está em `allocated_members` e, caso não esteja, o adiciona automaticamente no mesmo update enviado ao banco.

**Pontuação proporcional à complexidade do projeto**

A sobrecarga atribuída ao Scrum Master deixou de ser um valor fixo de `+2` e passou a ser calculada com base nos pontos de sobrecarga do projeto (`Math.max(1, Math.round(points * 0.4))`):

| Complexidade do projeto | Pontos do SM |
|---|---|
| Baixa (1–4 pts) | +1 |
| Média (5–6 pts) | +2 |
| Alta (7–8 pts) | +3 |
| Crítica (9–10 pts) | +4 |

O mínimo garantido é sempre `+1`. Projetos de complexidade média (5 pts) continuam gerando `+2`, mantendo compatibilidade com o comportamento anterior.

### Arquivos alterados
- `js/scrum.js` — removida validação de pré-alocação no formulário
- `js/supabase.js` — `definirScrumMaster` agora adiciona o SM ao `allocated_members` se necessário
- `js/app.js` — `calculateOverload` usa fórmula proporcional em vez de valor fixo